### PR TITLE
Scaleway (FR-PAR): add storage class ONEZONE_IA

### DIFF
--- a/Scaleway (FR-PAR).cyberduckprofile
+++ b/Scaleway (FR-PAR).cyberduckprofile
@@ -40,7 +40,7 @@
         </array>
         <key>Properties</key>
         <array>
-            <string>s3.storage.class.options=STANDARD GLACIER</string>
+            <string>s3.storage.class.options=STANDARD ONEZONE_IA GLACIER</string>
         </array>
         <key>Help</key>
         <string>https://docs.cyberduck.io/protocols/s3/scaleway/</string>

--- a/Scaleway (PL-WAW).cyberduckprofile
+++ b/Scaleway (PL-WAW).cyberduckprofile
@@ -40,7 +40,7 @@
         </array>
         <key>Properties</key>
         <array>
-            <string>s3.storage.class.options=STANDARD GLACIER</string>
+            <string>s3.storage.class.options=STANDARD</string>
         </array>
         <key>Help</key>
         <string>https://docs.cyberduck.io/protocols/s3/scaleway/</string>


### PR DESCRIPTION
Paris location supports a third storage class `One Zone - Infrequent Access` https://www.scaleway.com/en/docs/storage/object/concepts/#storage-class

Currently this storage class is only available in PAR.