### PR TITLE
Allow configuration with no AWS credentials.

### DIFF
--- a/S3 (HTTPS).cyberduckprofile
+++ b/S3 (HTTPS).cyberduckprofile
@@ -18,5 +18,7 @@
         <true/>
         <key>Username Configurable</key>
         <true/>
+        <key>Anonymous Configurable</key>
+        <true/>
     </dict>
 </plist>


### PR DESCRIPTION
Resolves #75.