### PR TITLE
Add connection profile for ownCloud Infinite Scale with OpenID Connect

### DIFF
--- a/ocis.ocis-keycloak.latest.owncloud.works.cyberduckprofile
+++ b/ocis.ocis-keycloak.latest.owncloud.works.cyberduckprofile
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2002-2022 iterate GmbH. All rights reserved.
+  ~ https://cyberduck.io/
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  -->
+
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Protocol</key>
+        <string>owncloud</string>
+        <key>Vendor</key>
+        <string>owncloud.works</string>
+        <key>Description</key>
+        <string>ownCloud Infinite Scale</string>
+        <key>Default Nickname</key>
+        <string>ownCloud Infinite Scale</string>
+        <key>Default Hostname</key>
+        <string>ocis.ocis-keycloak.latest.owncloud.works</string>
+        <key>Default Path</key>
+        <string>/remote.php/webdav/</string>
+        <key>Path Configurable</key>
+        <true/>
+        <key>Hostname Configurable</key>
+        <true/>
+        <key>OAuth Configurable</key>
+        <true/>
+        <key>OAuth Authorization Url</key>
+        <string>https://keycloak.ocis-keycloak.latest.owncloud.works/realms/oCIS/protocol/openid-connect/auth</string>
+        <key>OAuth Token Url</key>
+        <string>https://keycloak.ocis-keycloak.latest.owncloud.works/realms/oCIS/protocol/openid-connect/token</string>
+        <key>Scopes</key>
+        <array>
+            <string>openid</string>
+            <string>email</string>
+            <string>offline_access</string>
+        </array>
+        <key>OAuth Client ID</key>
+        <string>3keLfua0olYvW1zKXTDB3OjAMPEYWEQNuiscli395GKJOiPnPURNQWGvGCJZf4Hw</string>
+        <key>OAuth Client Secret</key>
+        <string>yoqICbLIeYbpZPqDH4D8k4NKb04HqnrWBntEeVZEQ5gO1RmaUlln0Aqu1dj2UoF4</string>
+        <key>OAuth Redirect Url</key>
+        <string>${oauth.handler.scheme}:oauth</string>
+        <key>Password Configurable</key>
+        <false/>
+        <key>Username Configurable</key>
+        <false/>
+    </dict>
+</plist>


### PR DESCRIPTION
Adds `ownCloud Infinite Scale (OpenID Connect).cyberduckprofile` to connect to ownCloud Infinite Scale (oCIS) deployments using the built-in identity provider without requiring any client registration.

- Uses the `ownCloud desktop app` client registered by default in the built-in identity provider (`services/idp/pkg/config/defaults/defaultconfig.go`) with redirect URIs `http://127.0.0.1` and `http://localhost` accepting any port for native clients.
- The client is confidential. The default client secret published with the oCIS configuration is set in `OAuth Client Secret` as it is validated by the token endpoint.
- `OAuth Redirect Url` set to `http://localhost/` using the loopback redirect handler.
- Relative `OAuth Authorization Url` (`/signin/v1/identifier/_/authorize`) and `OAuth Token Url` (`/konnect/v1/token`) resolved against the hostname of the bookmark.
- Scopes `openid profile email offline_access`. The identity provider requires consent for the untrusted client on first login to issue a refresh token.
- Replaces the previous sample profile for the Keycloak demo instance at `ocis.ocis-keycloak.latest.owncloud.works` which is no longer available.

### Notes
- Requires support for loopback redirect URIs without a port in iterate-ch/cyberduck#18448.
- Deployments using Keycloak or Microsoft Entra ID require a custom connection profile.
- Companion profile for OpenCloud in #198.
- Documentation in iterate-ch/docs#662.
