### PR TITLE
Update Contabo Object Storage (EU2).cyberduckprofile

### DIFF
--- a/Contabo Object Storage (EU2).cyberduckprofile
+++ b/Contabo Object Storage (EU2).cyberduckprofile
@@ -41,5 +41,9 @@
         <array>
             <string>default</string>
         </array>
+	<key>Properties</key>
+	<array>
+		<string>s3.bucket.virtualhost.disable=true</string>
+	</array>
     </dict>
 </plist>


### PR DESCRIPTION
Current Contabo Object Storage profile is not working because they do not support virtual addressing, only path style. This change fixes it