### PR TITLE
Update Public Cloud Region 1 and add Region 2

### DIFF
--- a/Infomaniak Public Cloud 01 (S3).cyberduckprofile
+++ b/Infomaniak Public Cloud 01 (S3).cyberduckprofile
@@ -23,12 +23,10 @@
         <string>Infomaniak Network</string>
         <key>Scheme</key>
         <string>https</string>
-        <key>Name</key>
-        <string>Infomaniak Public Cloud (S3)</string>
         <key>Description</key>
-        <string>Infomaniak Public Cloud Region 1 (S3)</string>
+        <string>Infomaniak Public Cloud (dc3-a) (S3)</string>
         <key>Default Nickname</key>
-        <string>Infomaniak Public Cloud (S3)</string>
+        <string>Infomaniak Public Cloud (dc3-a) (S3)</string>
         <key>Default Hostname</key>
         <string>s3.pub1.infomaniak.cloud</string>
         <key>Hostname Configurable</key>

--- a/Infomaniak Public Cloud 02 (S3).cyberduckprofile
+++ b/Infomaniak Public Cloud 02 (S3).cyberduckprofile
@@ -18,32 +18,27 @@
 <plist version="1.0">
     <dict>
         <key>Protocol</key>
-        <string>swift</string>
+        <string>s3</string>
         <key>Vendor</key>
         <string>Infomaniak Network</string>
-        <key>Default Nickname</key>
-        <string>Infomaniak Public Cloud (dc3-a) (Swift)</string>
+        <key>Scheme</key>
+        <string>https</string>
         <key>Description</key>
-        <string>Infomaniak Public Cloud (dc3-a) (Swift)</string>
-        <key>Context</key>
-        <string>/identity/v3/auth/tokens</string>
+        <string>Infomaniak Public Cloud (dc4-a) (S3)</string>
+        <key>Default Nickname</key>
+        <string>Infomaniak Public Cloud (dc4-a) (S3)</string>
         <key>Default Hostname</key>
-        <string>api.pub1.infomaniak.cloud</string>
-	    <key>Region</key>
-	    <string>dc3-a</string>
+        <string>s3.pub2.infomaniak.cloud</string>
         <key>Hostname Configurable</key>
         <false/>
-        <key>Default Port</key>
-        <string>443</string>
         <key>Port Configurable</key>
         <false/>
-        <key>Username Placeholder</key>
-        <string>Project:Domain:Username</string>
-        <key>Password Placeholder</key>
-        <string>Password</string>
-        <key>Schemes</key>
+        <key>Anonymous Configurable</key>
+        <false/>
+        <key>Properties</key>
         <array>
-            <string>infomaniak</string>
+            <string>s3.bucket.virtualhost.disable=true</string>
+            <string>s3.storage.class.options=STANDARD</string>
         </array>
         <key>Help</key>
         <string>https://trac.cyberduck.io/wiki/help/en/howto/infomaniak</string>

--- a/Infomaniak Public Cloud 02 (Swift).cyberduckprofile
+++ b/Infomaniak Public Cloud 02 (Swift).cyberduckprofile
@@ -22,21 +22,21 @@
         <key>Vendor</key>
         <string>Infomaniak Network</string>
         <key>Default Nickname</key>
-        <string>Infomaniak Public Cloud (dc3-a) (Swift)</string>
+        <string>Infomaniak Public Cloud (dc4-a) (Swift)</string>
         <key>Description</key>
-        <string>Infomaniak Public Cloud (dc3-a) (Swift)</string>
+        <string>Infomaniak Public Cloud (dc4-a) (Swift)</string>
         <key>Context</key>
         <string>/identity/v3/auth/tokens</string>
         <key>Default Hostname</key>
         <string>api.pub1.infomaniak.cloud</string>
-	    <key>Region</key>
-	    <string>dc3-a</string>
         <key>Hostname Configurable</key>
         <false/>
         <key>Default Port</key>
         <string>443</string>
         <key>Port Configurable</key>
         <false/>
+	    <key>Region</key>
+	    <string>dc4-a</string>
         <key>Username Placeholder</key>
         <string>Project:Domain:Username</string>
         <key>Password Placeholder</key>


### PR DESCRIPTION
Infomaniak has released a second region for their cloud infrastructure services (Infomaniak Public Cloud).

I have updated the existing profiles to support region names, and created two new profiles for the second region. All protocols (Swift and S3) are supported.

Updated profiles for Region 1 (dc3-a):

    - Infomaniak Public Cloud 01 (S3).cyberduckprofile

    - Infomaniak Public Cloud 01 (Swift).cyberduckprofile

New profiles for Region 2 (dc4-a):

    - Infomaniak Public Cloud 02 (S3).cyberduckprofile

    - Infomaniak Public Cloud 02 (Swift).cyberduckprofile