### PR TITLE
Reapply GroupMember.Read.All to CLI profile (required for Group DisplayName)

### DIFF
--- a/Microsoft SharePoint (CLI).cyberduckprofile
+++ b/Microsoft SharePoint (CLI).cyberduckprofile
@@ -36,6 +36,7 @@
             <string>sites.readwrite.all</string>
             <string>files.readwrite.all</string>
             <string>user.read</string>
+            <string>groupmember.read.all</string>
             <string>offline_access</string>
         </array>
         <key>OAuth Client ID</key>


### PR DESCRIPTION
See iterate-ch/cyberduck#17304