### PR TITLE
update Linode endpoints based on latest TechDocs

### DIFF
--- a/Linode Object Storage (ap-south-1)(e0).cyberduckprofile
+++ b/Linode Object Storage (ap-south-1)(e0).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Singapore, SG) (ap-south-1) (Type=E0)</string>
+        <string>Linode Object Storage (Singapore, SG) (ap-south-1) (Type=E0) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>ap-south-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (au-mel-1)(e2).cyberduckprofile
+++ b/Linode Object Storage (au-mel-1)(e2).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Melbourne, AU) (au-mel-1) (Type=E2)</string>
+        <string>Linode Object Storage (Melbourne, AU) (au-mel-1) (Type=E2) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>au-mel-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (de-fra-1)(e3).cyberduckprofile
+++ b/Linode Object Storage (de-fra-1)(e3).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Frankfurt 2, DE) (de-fra-1) (Type=E3) (Limited Availability)</string>
+        <string>Linode Object Storage (Frankfurt 2, DE) (de-fra-1) (Type=E3)</string>
         <key>Default Hostname</key>
         <string>de-fra-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (es-mad-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (es-mad-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Madrid, ES) (es-mad-1) (Type=E1)</string>
+        <string>Linode Object Storage (Madrid, ES) (es-mad-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>es-mad-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (eu-central-1)(e0).cyberduckprofile
+++ b/Linode Object Storage (eu-central-1)(e0).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Frankfurt, DE) (eu-central-1) (Type=E0)</string>
+        <string>Linode Object Storage (Frankfurt, DE) (eu-central-1) (Type=E0) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>eu-central-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (it-mil-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (it-mil-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Milan, IT) (it-mil-1) (Type=E1)</string>
+        <string>Linode Object Storage (Milan, IT) (it-mil-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>it-mil-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (jp-osa-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (jp-osa-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Osaka, JP) (jp-osa-1) (Type=E1)</string>
+        <string>Linode Object Storage (Osaka, JP) (jp-osa-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>jp-osa-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (jp-tyo-1)(e3).cyberduckprofile
+++ b/Linode Object Storage (jp-tyo-1)(e3).cyberduckprofile
@@ -20,13 +20,13 @@
         <key>Protocol</key>
         <string>s3</string>
         <key>Vendor</key>
-        <string>linode-us-iad-1</string>
+        <string>linode-jp-tyo-1</string>
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Washington, DC, US) (us-iad-1) (Type=E1) (Limited Availability)</string>
+        <string>Linode Object Storage (Tokyo 3, JP) (jp-tyo-1) (Type=E3)</string>
         <key>Default Hostname</key>
-        <string>us-iad-1.linodeobjects.com</string>
+        <string>jp-tyo-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>
         <false/>
         <key>Port Configurable</key>
@@ -38,10 +38,10 @@
         <key>Authorization</key>
         <string>AWS4HMACSHA256</string>
         <key>Region</key>
-        <string>us-iad-1</string>
+        <string>jp-tyo-1</string>
         <key>Regions</key>
         <array>
-            <string>us-iad-1</string>
+            <string>jp-tyo-1</string>
         </array>
         <key>Properties</key>
         <dict>

--- a/Linode Object Storage (nl-ams-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (nl-ams-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Amsterdam, NL) (nl-ams-1) (Type=E1)</string>
+        <string>Linode Object Storage (Amsterdam, NL) (nl-ams-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>nl-ams-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (se-sto-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (se-sto-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Stockholm, SE) (se-sto-1) (Type=E1)</string>
+        <string>Linode Object Storage (Stockholm, SE) (se-sto-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>se-sto-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-east-1)(e0).cyberduckprofile
+++ b/Linode Object Storage (us-east-1)(e0).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Newark, NJ, US) (us-east-1) (Type=E0)</string>
+        <string>Linode Object Storage (Newark, NJ, US) (us-east-1) (Type=E0) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>us-east-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-iad-10)(e1).cyberduckprofile
+++ b/Linode Object Storage (us-iad-10)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Washington, DC, US) (us-iad-10) (Type=E1)</string>
+        <string>Linode Object Storage (Washington, DC, US) (us-iad-10) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>us-iad-10.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-iad-18)(e3).cyberduckprofile
+++ b/Linode Object Storage (us-iad-18)(e3).cyberduckprofile
@@ -20,13 +20,13 @@
         <key>Protocol</key>
         <string>s3</string>
         <key>Vendor</key>
-        <string>linode-jp-tyo-1</string>
+        <string>linode-us-iad-18</string>
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Tokyo 3, JP) (jp-tyo-1) (Type=E2)</string>
+        <string>Linode Object Storage (Washington 2, DC, US) (us-iad-18) (Type=E3)</string>
         <key>Default Hostname</key>
-        <string>jp-tyo-1.linodeobjects.com</string>
+        <string>us-iad-18.linodeobjects.com</string>
         <key>Hostname Configurable</key>
         <false/>
         <key>Port Configurable</key>
@@ -38,10 +38,10 @@
         <key>Authorization</key>
         <string>AWS4HMACSHA256</string>
         <key>Region</key>
-        <string>jp-tyo-1</string>
+        <string>us-iad-18</string>
         <key>Regions</key>
         <array>
-            <string>jp-tyo-1</string>
+            <string>us-iad-18</string>
         </array>
         <key>Properties</key>
         <dict>

--- a/Linode Object Storage (us-lax-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (us-lax-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Los Angeles, CA, US) (us-lax-1) (Type=E1)</string>
+        <string>Linode Object Storage (Los Angeles, CA, US) (us-lax-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>us-lax-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-lax-4)(e3).cyberduckprofile
+++ b/Linode Object Storage (us-lax-4)(e3).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Los Angeles, CA, US) (us-lax-4) (Type=E3) (Limited Availability)</string>
+        <string>Linode Object Storage (Los Angeles, CA, US) (us-lax-4) (Type=E3)</string>
         <key>Default Hostname</key>
         <string>us-lax-4.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-mia-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (us-mia-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Miami, FL, US) (us-mia-1) (Type=E1)</string>
+        <string>Linode Object Storage (Miami, FL, US) (us-mia-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>us-mia-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-ord-1)(e1).cyberduckprofile
+++ b/Linode Object Storage (us-ord-1)(e1).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Chicago, IL, US) (us-ord-1) (Type=E1)</string>
+        <string>Linode Object Storage (Chicago, IL, US) (us-ord-1) (Type=E1) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>us-ord-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-ord-10)(e3).cyberduckprofile
+++ b/Linode Object Storage (us-ord-10)(e3).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Chicago, IL, US) (us-ord-10) (Type=E3) (Limited Availability)</string>
+        <string>Linode Object Storage (Chicago, IL, US) (us-ord-10) (Type=E3)</string>
         <key>Default Hostname</key>
         <string>us-ord-10.linodeobjects.com</string>
         <key>Hostname Configurable</key>

--- a/Linode Object Storage (us-southeast-1)(e0).cyberduckprofile
+++ b/Linode Object Storage (us-southeast-1)(e0).cyberduckprofile
@@ -24,7 +24,7 @@
         <key>Scheme</key>
         <string>https</string>
         <key>Description</key>
-        <string>Linode Object Storage (Atlanta, GA, US) (us-southeast-1) (Type=E0)</string>
+        <string>Linode Object Storage (Atlanta, GA, US) (us-southeast-1) (Type=E0) (Limited Availability)</string>
         <key>Default Hostname</key>
         <string>us-southeast-1.linodeobjects.com</string>
         <key>Hostname Configurable</key>


### PR DESCRIPTION
Hello Cyberduck maintainers,

I used my automation mentioned in #158 to produce updated Cyberduck profiles based on the current data in our TechDocs:

https://techdocs.akamai.com/cloud-computing/docs/endpoint-types

These changes are largely around endpoints moving into and out of Limited Availability, with one new endpoint added (us-iad-18).

I did notice our jp-tyo-1 endpoint changed types from E2 to E3, which would force a filename change according to the naming convention. I hope this isn't a problem.

Thanks for reviewing! 