### PR TITLE
Add new regions to CoreWeave AI Object Storage profile

### DIFF
--- a/CoreWeave AI Object Storage.cyberduckprofile
+++ b/CoreWeave AI Object Storage.cyberduckprofile
@@ -39,22 +39,27 @@
         <string>AWS4HMACSHA256</string>
         <key>Regions</key>
         <array>
+            <string>ca-east-01a</string>
+            <string>eu-south-03b</string>
+            <string>eu-south-04a</string>
+            <string>us-central-05a</string>
+            <string>us-central-06a</string>
+            <string>us-central-07a</string>
+            <string>us-central-08a</string>
+            <string>us-central-08b</string>
             <string>us-east-01a</string>
             <string>us-east-02a</string>
             <string>us-east-03a</string>
             <string>us-east-04a</string>
+            <string>us-east-04b</string>
             <string>us-east-06a</string>
             <string>us-east-08a</string>
             <string>us-east-13a</string>
             <string>us-east-14a</string>
-            <string>us-central-06a</string>
-            <string>us-central-07a</string>
             <string>rno2a</string>
             <string>us-west-01a</string>
             <string>us-west-04a</string>
             <string>us-west-09b</string>
-            <string>eu-south-03b</string>
-            <string>eu-south-04a</string>
         </array>
         <key>Properties</key>
         <array>


### PR DESCRIPTION
Added the following availability zones to match this website with the canonical list:
https://docs.coreweave.com/platform/regions/all-availability-zones us-east-04b
us-central-05a
us-central-08a
us-central-08b
ca-east-01a